### PR TITLE
fixed: undefined method column_types

### DIFF
--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -81,7 +81,9 @@ module Administrate
         if enum_column?(attr)
           :enum
         else
-          klass.column_types[attr].type
+          column = klass.columns_hash[attr]
+          return if column.nil?
+          column.type
         end
       end
 


### PR DESCRIPTION
Using this gem with `rails 5.0.0.beta4`, I received the error: `undefined method ' column_types'` when running the `administrate:install` task. The error originated from `DashboardGenerator#column_type_for_attribute`. The receiver of the call to `column_types` was an instance of `ConnectionAdapters::Column`, which has apparently never implemented that method.

Anyway, I replaced it with a call to `columns_hash`. I also return nil if no column matching the attribute exists. This is needed to support relationship attributes.
